### PR TITLE
Decouple peer handle and socket handle

### DIFF
--- a/ublox-short-range/src/command/data_mode/mod.rs
+++ b/ublox-short-range/src/command/data_mode/mod.rs
@@ -6,9 +6,8 @@ pub mod urc;
 use atat::atat_derive::AtatCmd;
 use responses::*;
 use types::*;
-use ublox_sockets::SocketHandle;
 
-use super::NoResponse;
+use super::{NoResponse, PeerHandle};
 
 /// 5.1 Enter data mode O
 ///
@@ -41,7 +40,7 @@ pub struct ConnectPeer<'a> {
 #[at_cmd("+UDCPC", NoResponse, timeout_ms = 10000)]
 pub struct ClosePeerConnection {
     #[at_arg(position = 0)]
-    pub peer_handle: SocketHandle,
+    pub peer_handle: PeerHandle,
 }
 
 /// 5.4 Default remote peer +UDDRP

--- a/ublox-short-range/src/command/data_mode/responses.rs
+++ b/ublox-short-range/src/command/data_mode/responses.rs
@@ -1,4 +1,5 @@
 //! Responses for Data Mode
+use super::PeerHandle;
 use atat::atat_derive::AtatResp;
 use heapless::String;
 
@@ -6,14 +7,14 @@ use heapless::String;
 #[derive(Clone, AtatResp)]
 pub struct ConnectPeerResponse {
     #[at_arg(position = 0)]
-    pub peer_handle: u8,
+    pub peer_handle: PeerHandle,
 }
 
 /// 5.5 Peer list +UDLP
 #[derive(Clone, AtatResp)]
 pub struct PeerListResponse {
     #[at_arg(position = 0)]
-    pub peer_handle: usize,
+    pub peer_handle: PeerHandle,
     #[at_arg(position = 1)]
     pub protocol: String<64>,
     #[at_arg(position = 2)]

--- a/ublox-short-range/src/command/data_mode/urc.rs
+++ b/ublox-short-range/src/command/data_mode/urc.rs
@@ -1,14 +1,15 @@
 //! Unsolicited responses for Data mode Commands
+use crate::command::PeerHandle;
+
 use super::types::*;
 use atat::atat_derive::AtatResp;
 use atat::heapless_bytes::Bytes;
-use ublox_sockets::SocketHandle;
 
 /// 5.10 Peer connected +UUDPC
 #[derive(Debug, PartialEq, Clone, AtatResp)]
 pub struct PeerConnected {
     #[at_arg(position = 0)]
-    pub handle: SocketHandle,
+    pub handle: PeerHandle,
     #[at_arg(position = 1)]
     pub connection_type: ConnectionType,
     #[at_arg(position = 2)]
@@ -31,5 +32,5 @@ pub struct PeerConnected {
 #[derive(Debug, PartialEq, Clone, AtatResp)]
 pub struct PeerDisconnected {
     #[at_arg(position = 0)]
-    pub handle: SocketHandle,
+    pub handle: PeerHandle,
 }

--- a/ublox-short-range/src/command/edm/urc.rs
+++ b/ublox-short-range/src/command/edm/urc.rs
@@ -141,9 +141,10 @@ impl AtatUrc for EdmEvent {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::command::{data_mode::urc::PeerDisconnected, edm::types::DATA_PACKAGE_SIZE, Urc};
+    use crate::command::{
+        data_mode::urc::PeerDisconnected, edm::types::DATA_PACKAGE_SIZE, PeerHandle, Urc,
+    };
     use atat::{heapless::Vec, AtatUrc};
-    use ublox_sockets::SocketHandle;
 
     #[test]
     fn parse_at_urc() {
@@ -169,7 +170,7 @@ mod test {
             // 0xAAu8, 0x00, 0x1B, 0x00, 0x41, 0x2B, 0x55, 0x55, 0x57, 0x4C, 0x45, 0x3A, 0x30, 0x2C, 0x33, 0x32, 0x41, 0x42, 0x36, 0x41, 0x37, 0x41, 0x34, 0x30, 0x34, 0x34, 0x2C, 0x31, 0x0D, 0x0A, 0x55,
         ];
         let urc = EdmEvent::ATEvent(Urc::PeerDisconnected(PeerDisconnected {
-            handle: SocketHandle(3),
+            handle: PeerHandle(3),
         }));
         let parsed_urc = EdmEvent::parse(resp);
         assert_eq!(parsed_urc, Some(urc), "Parsing URC failed");

--- a/ublox-short-range/src/command/mod.rs
+++ b/ublox-short-range/src/command/mod.rs
@@ -13,7 +13,8 @@ pub mod security;
 pub mod system;
 pub mod wifi;
 
-use atat::atat_derive::{AtatCmd, AtatResp, AtatUrc};
+use atat::atat_derive::{AtatCmd, AtatLen, AtatResp, AtatUrc};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, AtatResp, PartialEq)]
 pub struct NoResponse;
@@ -21,6 +22,23 @@ pub struct NoResponse;
 #[derive(Debug, Clone, AtatCmd)]
 #[at_cmd("", NoResponse, timeout_ms = 1000)]
 pub struct AT;
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    AtatLen,
+    Ord,
+    Default,
+    Serialize,
+    Deserialize,
+    defmt::Format,
+    hash32_derive::Hash32,
+)]
+pub struct PeerHandle(u8);
 
 #[derive(Debug, PartialEq, Clone, AtatUrc)]
 pub enum Urc {

--- a/ublox-short-range/src/wifi/mod.rs
+++ b/ublox-short-range/src/wifi/mod.rs
@@ -1,3 +1,4 @@
+use crate::command::PeerHandle;
 use ublox_sockets::SocketHandle;
 
 use crate::command::edm::types::ChannelId;
@@ -19,38 +20,75 @@ pub mod udp_stack;
 pub mod tcp_stack;
 
 pub(crate) const EGRESS_CHUNK_SIZE: usize = 512;
+/// The socket map, keeps mappings between `ublox::sockets`s `SocketHandle`,
+/// and the modems `PeerHandle` and `ChannelId`. The peer handle is used
+/// for controlling the connection, while the channel id is used for sending
+/// data over the connection in EDM mode.
+pub struct SocketMap {
+    channel_map: heapless::FnvIndexMap<ChannelId, SocketHandle, 4>,
+    peer_map: heapless::FnvIndexMap<PeerHandle, SocketHandle, 4>,
+}
 
-pub struct EdmMap(heapless::FnvIndexMap<ChannelId, SocketHandle, 8>);
-
-impl Default for EdmMap {
+impl Default for SocketMap {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl EdmMap {
-    pub fn new() -> Self {
-        Self(heapless::FnvIndexMap::new())
+impl SocketMap {
+    fn new() -> Self {
+        Self {
+            channel_map: heapless::FnvIndexMap::new(),
+            peer_map: heapless::FnvIndexMap::new(),
+        }
     }
 
-    pub fn insert(&mut self, channel_id: ChannelId, socket_handle: SocketHandle) -> Result<(), ()> {
-        defmt::trace!("[EDM_MAP] {:?} tied to {:?}", socket_handle, channel_id);
-        self.0.insert(channel_id, socket_handle).map_err(drop)?;
+    pub fn insert_channel(
+        &mut self,
+        channel_id: ChannelId,
+        socket_handle: SocketHandle,
+    ) -> Result<(), ()> {
+        defmt::trace!("[SOCK_MAP] {:?} tied to {:?}", socket_handle, channel_id);
+        self.channel_map
+            .insert(channel_id, socket_handle)
+            .map_err(drop)?;
         Ok(())
     }
 
-    pub fn remove(&mut self, channel_id: &ChannelId) -> Result<(), ()> {
-        defmt::trace!("[EDM_MAP] {:?} removed", channel_id);
-        self.0.remove(channel_id).ok_or(())?;
+    pub fn remove_channel(&mut self, channel_id: &ChannelId) -> Result<(), ()> {
+        defmt::trace!("[SOCK_MAP] {:?} removed", channel_id);
+        self.channel_map.remove(channel_id).ok_or(())?;
         Ok(())
     }
 
-    pub fn socket_handle(&self, channel_id: &ChannelId) -> Option<&SocketHandle> {
-        self.0.get(channel_id)
+    pub fn channel_to_socket(&self, channel_id: &ChannelId) -> Option<&SocketHandle> {
+        self.channel_map.get(channel_id)
     }
 
-    pub fn channel_id(&self, socket_handle: &SocketHandle) -> Option<&ChannelId> {
-        self.0
+    pub fn socket_to_channel_id(&self, socket_handle: &SocketHandle) -> Option<&ChannelId> {
+        self.channel_map
+            .iter()
+            .find_map(|(c, s)| if s == socket_handle { Some(c) } else { None })
+    }
+
+    pub fn insert_peer(&mut self, peer: PeerHandle, socket_handle: SocketHandle) -> Result<(), ()> {
+        defmt::trace!("[SOCK_MAP] {:?} tied to {:?}", socket_handle, peer);
+        self.peer_map.insert(peer, socket_handle).map_err(drop)?;
+        Ok(())
+    }
+
+    pub fn remove_peer(&mut self, peer: &PeerHandle) -> Result<(), ()> {
+        defmt::trace!("[SOCK_MAP] {:?} removed", peer);
+        self.peer_map.remove(peer).ok_or(())?;
+        Ok(())
+    }
+
+    pub fn peer_to_socket(&self, peer: &PeerHandle) -> Option<&SocketHandle> {
+        self.peer_map.get(peer)
+    }
+
+    pub fn socket_to_peer(&self, socket_handle: &SocketHandle) -> Option<&PeerHandle> {
+        self.peer_map
             .iter()
             .find_map(|(c, s)| if s == socket_handle { Some(c) } else { None })
     }


### PR DESCRIPTION
Create independent socket handles and extend the map structure to encompass a mapping to peer handles.

So far only tested with and unresponsive AWS, but syncs time and seems good.

Fixes: #31 #30  