### PR TITLE
feature[Supplicant] Active on startup managing now possible

### DIFF
--- a/ublox-short-range/src/client.rs
+++ b/ublox-short-range/src/client.rs
@@ -246,9 +246,12 @@ where
         self.initialized = false;
         self.module_started = false;
         self.wifi_connection = None;
+        self.wifi_config_active_on_startup = None;
+        self.dns_state = DNSState::NotResolving;
         self.urc_attempts = 0;
         self.security_credentials = SecurityCredentials::default();
         self.socket_map = SocketMap::default();
+        self.udp_listener = UdpListener::new();
 
         self.clear_buffers()?;
 
@@ -815,13 +818,15 @@ where
         }
     }
 
-
     /// Is the module attached to a WiFi
+    ///
+    /// WiFi connection can disconnect momentarily, but if the network state does not change
+    /// the current context is safe.
     pub fn attached_to_wifi(&self) -> Result<(), Error> {
         if let Some(ref con) = self.wifi_connection {
             if !self.initialized {
                 Err(Error::Uninitialized)
-            } else if !con.is_connected() {
+            } else if !(con.network_state == NetworkState::Attached) {
                 Err(Error::WifiState(con.wifi_state))
             } else {
                 Ok(())

--- a/ublox-short-range/src/client.rs
+++ b/ublox-short-range/src/client.rs
@@ -24,8 +24,9 @@ use crate::{
     error::Error,
     wifi::{
         connection::{NetworkState, WiFiState, WifiConnection},
+        network::{WifiMode, WifiNetwork},
         supplicant::Supplicant,
-        SocketMap, network::{WifiNetwork, WifiMode},
+        SocketMap,
     },
 };
 use atat::clock::Clock;
@@ -80,6 +81,7 @@ where
     CLK: Clock<TIMER_HZ>,
     RST: OutputPin,
 {
+    pub(crate) module_started: bool,
     pub(crate) initialized: bool,
     serial_mode: SerialMode,
     pub(crate) wifi_connection: Option<WifiConnection>,
@@ -104,6 +106,7 @@ where
 {
     pub fn new(client: C, timer: CLK, config: Config<RST>) -> Self {
         UbloxClient {
+            module_started: false,
             initialized: false,
             serial_mode: SerialMode::Cmd,
             wifi_connection: None,
@@ -141,9 +144,16 @@ where
         self.reset()?;
 
         // Switch to EDM on Init. If in EDM, fail and check with autosense
-        if self.serial_mode != SerialMode::ExtendedData {
-            self.retry_send(&SwitchToEdmCommand, 5)?;
-            self.serial_mode = SerialMode::ExtendedData;
+        // if self.serial_mode != SerialMode::ExtendedData {
+        //     self.retry_send(&SwitchToEdmCommand, 5)?;
+        //     self.serial_mode = SerialMode::ExtendedData;
+        // }
+
+        while self.serial_mode != SerialMode::ExtendedData {
+            self.send_internal(&SwitchToEdmCommand, true).ok();
+            self.timer.start(100.millis()).map_err(|_| Error::Timer)?;
+            nb::block!(self.timer.wait()).map_err(|_| Error::Timer)?;
+            while self.handle_urc()? {}
         }
 
         // TODO: handle EDM settings quirk see EDM datasheet: 2.2.5.1 AT Request Serial settings
@@ -234,6 +244,7 @@ where
     pub fn reset(&mut self) -> Result<(), Error> {
         self.serial_mode = SerialMode::Cmd;
         self.initialized = false;
+        self.module_started = false;
         self.wifi_connection = None;
         self.urc_attempts = 0;
         self.security_credentials = SecurityCredentials::default();
@@ -242,14 +253,26 @@ where
         self.clear_buffers()?;
 
         if let Some(ref mut pin) = self.config.rst_pin {
+            defmt::warn!("Hard resetting Ublox Short Range");
             pin.set_low().ok();
             self.timer.start(50.millis()).map_err(|_| Error::Timer)?;
             nb::block!(self.timer.wait()).map_err(|_| Error::Timer)?;
 
             pin.set_high().ok();
 
-            self.timer.start(3.secs()).map_err(|_| Error::Timer)?;
-            nb::block!(self.timer.wait()).map_err(|_| Error::Timer)?;
+            self.timer.start(4.secs()).map_err(|_| Error::Timer)?;
+            loop {
+                match self.timer.wait() {
+                    Ok(()) => return Err(Error::_Unknown),
+                    Err(nb::Error::WouldBlock) => {
+                        self.handle_urc().ok();
+                        if self.module_started {
+                            break;
+                        }
+                    }
+                    Err(_) => return Err(Error::Timer),
+                }
+            }
         }
         Ok(())
     }
@@ -324,6 +347,13 @@ where
             let res = match edm_urc {
                 EdmEvent::ATEvent(urc) => {
                     match urc {
+                        Urc::StartUp => {
+                            debug!("[URC] Startup");
+                            self.module_started = true;
+                            self.initialized = false;
+                            self.serial_mode = SerialMode::Cmd;
+                            true
+                        }
                         Urc::PeerConnected(event) => {
                             debug!("[URC] PeerConnected");
 
@@ -570,6 +600,8 @@ where
                 } // end match urc
                 EdmEvent::StartUp => {
                     debug!("[EDM_URC] STARTUP");
+                    self.module_started = true;
+                    self.serial_mode = SerialMode::ExtendedData;
                     true
                 }
                 EdmEvent::IPv4ConnectEvent(event) => {

--- a/ublox-short-range/src/client.rs
+++ b/ublox-short-range/src/client.rs
@@ -482,9 +482,9 @@ where
                             debug!("[URC] WifiLinkDisconnected");
                             if let Some(con) = wifi_connection {
                                 match msg.reason {
-                                    // DisconnectReason::NetworkDisabled => {
-                                    //     con.wifi_state = WiFiState::Inactive;
-                                    // }
+                                    DisconnectReason::NetworkDisabled => {
+                                        con.wifi_state = WiFiState::Inactive;
+                                    }
                                     DisconnectReason::SecurityProblems => {
                                         error!("Wifi Security Problems");
                                     }

--- a/ublox-short-range/src/client.rs
+++ b/ublox-short-range/src/client.rs
@@ -798,7 +798,7 @@ where
             active_on_startup: &mut self.wifi_config_active_on_startup,
         })
     }
-
+    /// Is the module attached to a WiFi and ready to open sockets
     pub fn connected_to_network(&self) -> Result<(), Error> {
         if let Some(ref con) = self.wifi_connection {
             if !self.initialized {
@@ -807,6 +807,22 @@ where
                 Err(Error::WifiState(con.wifi_state))
             } else if self.sockets.is_none() {
                 Err(Error::MissingSocketSet)
+            } else {
+                Ok(())
+            }
+        } else {
+            Err(Error::NoWifiSetup)
+        }
+    }
+
+
+    /// Is the module attached to a WiFi
+    pub fn attached_to_wifi(&self) -> Result<(), Error> {
+        if let Some(ref con) = self.wifi_connection {
+            if !self.initialized {
+                Err(Error::Uninitialized)
+            } else if !con.is_connected() {
+                Err(Error::WifiState(con.wifi_state))
             } else {
                 Ok(())
             }

--- a/ublox-short-range/src/command/edm/mod.rs
+++ b/ublox-short-range/src/command/edm/mod.rs
@@ -223,6 +223,8 @@ pub struct SwitchToEdmCommand;
 impl atat::AtatCmd<6> for SwitchToEdmCommand {
     type Response = NoResponse;
 
+    const MAX_TIMEOUT_MS: u32 = 2000;
+
     fn as_bytes(&self) -> Vec<u8, 6> {
         ChangeMode {
             mode: data_mode::types::Mode::ExtendedDataMode,
@@ -234,20 +236,16 @@ impl atat::AtatCmd<6> for SwitchToEdmCommand {
 
     fn parse(
         &self,
-        resp: Result<&[u8], atat::InternalError>,
+        _resp: Result<&[u8], atat::InternalError>,
     ) -> core::result::Result<Self::Response, atat::Error> {
-        let resp = resp?;
-        // Parse EDM startup command
-        let correct = &[0xAA, 0x00, 0x02, 0x00, 0x71, 0x55]; // &[0xAA,0x00,0x06,0x00,0x45,0x4f,0x4b,0x0D,0x0a,0x55]; // AA 00 06 00 44 41 54 0D 0A 0D 0A 4F 4B 0D 0A 55 ?
-        if resp.len() != correct.len()
-            || resp
-                .windows(correct.len())
-                .position(|window| window == correct)
-                != Some(0)
-        {
-            // TODO: check this
-            return Err(atat::Error::InvalidResponse);
-        }
+        // let resp = resp?;
+        // // Parse EDM startup command
+        // let correct = &[0xAA, 0x00, 0x02, 0x00, 0x71, 0x55]; // &[0xAA,0x00,0x06,0x00,0x45,0x4f,0x4b,0x0D,0x0a,0x55]; // AA 00 06 00 44 41 54 0D 0A 0D 0A 4F 4B 0D 0A 55 ?
+        // if resp.len() != correct.len()
+        //     || resp[.. correct.len()] != *correct {
+        //     // TODO: check this
+        //     return Err(atat::Error::InvalidResponse);
+        // }
         Ok(NoResponse)
     }
 }

--- a/ublox-short-range/src/command/edm/types.rs
+++ b/ublox-short-range/src/command/edm/types.rs
@@ -35,6 +35,7 @@ pub const AT_COMMAND_POSITION: usize = 5;
 /// Index in packet at which payload starts
 pub const PAYLOAD_POSITION: usize = 3;
 pub const STARTUPMESSAGE: &[u8] = b"\r\n+STARTUP\r\n";
+pub const AUTOCONNECTMESSAGE: &[u8] = b"\r\n+UUWLE:0,966C7D936881,1\r\n";
 
 #[derive(Debug, PartialEq)]
 #[repr(u8)]
@@ -66,6 +67,7 @@ pub(crate) enum PayloadType {
     IPhoneEvent = 0x61,
     /// Sent when the module recovers from reset or at power on. This packet may need
     /// special module configuration to be transmitted.
+    /// Sent on entering EDM mode
     StartEvent = 0x71,
     Unknown = 0x00,
 }

--- a/ublox-short-range/src/command/edm/types.rs
+++ b/ublox-short-range/src/command/edm/types.rs
@@ -35,7 +35,7 @@ pub const AT_COMMAND_POSITION: usize = 5;
 /// Index in packet at which payload starts
 pub const PAYLOAD_POSITION: usize = 3;
 pub const STARTUPMESSAGE: &[u8] = b"\r\n+STARTUP\r\n";
-pub const AUTOCONNECTMESSAGE: &[u8] = b"\r\n+UUWLE:0,966C7D936881,1\r\n";
+pub const AUTOCONNECTMESSAGE: &[u8] = b"\r\n+UUWLE:0,XXXXXXXXXXXX,1\r\n";
 
 #[derive(Debug, PartialEq)]
 #[repr(u8)]

--- a/ublox-short-range/src/command/mod.rs
+++ b/ublox-short-range/src/command/mod.rs
@@ -42,6 +42,9 @@ pub struct PeerHandle(pub u8);
 
 #[derive(Debug, PartialEq, Clone, AtatUrc)]
 pub enum Urc {
+    /// Startup Message
+    #[at_urc("+STARTUP")]
+    StartUp,
     /// 5.10 Peer connected +UUDPC
     #[at_urc("+UUDPC")]
     PeerConnected(data_mode::urc::PeerConnected),

--- a/ublox-short-range/src/command/mod.rs
+++ b/ublox-short-range/src/command/mod.rs
@@ -13,7 +13,7 @@ pub mod security;
 pub mod system;
 pub mod wifi;
 
-use atat::atat_derive::{AtatCmd, AtatLen, AtatResp, AtatUrc};
+use atat::atat_derive::{AtatCmd, AtatLen, AtatResp, AtatUrc, AtatEnum};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, AtatResp, PartialEq)]
@@ -88,4 +88,30 @@ pub enum Urc {
     PingResponse(ping::urc::PingResponse),
     #[at_urc("+UUPINGER")]
     PingErrorResponse(ping::urc::PingErrorResponse),
+}
+
+
+#[derive(Clone, PartialEq, AtatEnum)]
+#[repr(u8)]
+pub enum OnOff {
+    On = 1,
+    Off = 0,
+}
+
+impl From<bool> for OnOff {
+    fn from(b: bool) -> Self {
+        match b {
+            true => Self::On,
+            false => Self::Off,
+        }
+    }
+}
+
+impl Into<bool> for OnOff {
+    fn into(self) -> bool {
+        match self {
+            Self::On => true,
+            Self::Off => false,
+        }
+    }
 }

--- a/ublox-short-range/src/command/mod.rs
+++ b/ublox-short-range/src/command/mod.rs
@@ -13,7 +13,7 @@ pub mod security;
 pub mod system;
 pub mod wifi;
 
-use atat::atat_derive::{AtatCmd, AtatLen, AtatResp, AtatUrc, AtatEnum};
+use atat::atat_derive::{AtatCmd, AtatEnum, AtatLen, AtatResp, AtatUrc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, AtatResp, PartialEq)]
@@ -89,7 +89,6 @@ pub enum Urc {
     #[at_urc("+UUPINGER")]
     PingErrorResponse(ping::urc::PingErrorResponse),
 }
-
 
 #[derive(Clone, PartialEq, AtatEnum)]
 #[repr(u8)]

--- a/ublox-short-range/src/command/wifi/mod.rs
+++ b/ublox-short-range/src/command/wifi/mod.rs
@@ -8,7 +8,7 @@ use heapless::Vec;
 use responses::*;
 use types::*;
 
-use super::NoResponse;
+use super::{NoResponse, OnOff};
 
 /// 7.1 Wi-Fi station configuration +UWSC
 ///
@@ -132,7 +132,7 @@ pub struct GetWatchdogConfig {
     #[at_arg(position = 0)]
     pub watchdog_setting: WatchdogSetting,
     #[at_arg(position = 1)]
-    pub value: bool,
+    pub value: OnOff,
 }
 
 /// 7.8 Wi-Fi Access point configuration +UWAPC

--- a/ublox-short-range/src/command/wifi/types.rs
+++ b/ublox-short-range/src/command/wifi/types.rs
@@ -1,11 +1,11 @@
 //! Argument and parameter types used by WiFi Commands and Responses
 
+use crate::command::OnOff;
 use atat::atat_derive::AtatEnum;
 use atat::heapless_bytes::Bytes;
 use embedded_nal::{Ipv4Addr, Ipv6Addr};
 use heapless::{String, Vec};
 use serde::Deserialize;
-use crate::command::OnOff;
 
 #[derive(Clone, PartialEq, AtatEnum)]
 #[repr(u16)]

--- a/ublox-short-range/src/command/wifi/types.rs
+++ b/ublox-short-range/src/command/wifi/types.rs
@@ -5,31 +5,7 @@ use atat::heapless_bytes::Bytes;
 use embedded_nal::{Ipv4Addr, Ipv6Addr};
 use heapless::{String, Vec};
 use serde::Deserialize;
-
-#[derive(Clone, PartialEq, AtatEnum)]
-#[repr(u8)]
-pub enum OnOff {
-    On = 1,
-    Off = 0,
-}
-
-impl From<bool> for OnOff {
-    fn from(b: bool) -> Self {
-        match b {
-            true => Self::On,
-            false => Self::Off,
-        }
-    }
-}
-
-impl Into<bool> for OnOff {
-    fn into(self) -> bool {
-        match self {
-            Self::On => true,
-            Self::Off => false,
-        }
-    }
-}
+use crate::command::OnOff;
 
 #[derive(Clone, PartialEq, AtatEnum)]
 #[repr(u16)]
@@ -222,7 +198,7 @@ pub enum WifiStationConfig {
     /// validated during authentication. Supported software versions 5.0.0
     /// onwards
     #[at_arg(value = 15)]
-    ValidateCACertificate(bool),
+    ValidateCACertificate(OnOff),
     /// IPv4 Mode - <param_val1> to set the way to retrieve an IP address
     /// - 1: Static
     /// - 2 (default): DHCP
@@ -254,7 +230,7 @@ pub enum WifiStationConfig {
     /// - Off: Disabled
     /// - On: Enabled
     #[at_arg(value = 106)]
-    AddressConflictDetection(bool),
+    AddressConflictDetection(OnOff),
     /// IPv6 Mode - <param_val1> to set the way to retrieve an IP address
     /// - 1 (default): Link Local IpAddress
     #[at_arg(value = 200)]
@@ -277,7 +253,7 @@ pub enum WifiStationConfig {
     /// - 1: Enabled To use WEP with open authentication, the WEP key index must
     ///   be different from zero (0).
     #[at_arg(value = 301)]
-    DTIMInPowerSave(bool),
+    DTIMInPowerSave(OnOff),
 }
 
 #[derive(Clone, PartialEq, AtatEnum)]
@@ -287,7 +263,7 @@ pub enum WifiStationConfigR {
     /// - Off (default): Inactive
     /// - On: active
     #[at_arg(value = 0)]
-    ActiveOnStartup(OnOff),
+    ActiveOnStartup(bool),
     ///  SSID - <param_val1> is the Service Set Identifier. The factory default
     /// value is an empty string ("").
     #[at_arg(value = 2)]
@@ -726,7 +702,7 @@ pub enum WifiConfig {
     /// - On: Drop the network when the Wi-Fi link is lost; data may be lost
     ///   with this option. Supported software versions 5.0.0 onwards
     #[at_arg(value = 10)]
-    DropNetworkOnLinkLoss(bool),
+    DropNetworkOnLinkLoss(OnOff),
     /// Force world mode
     /// - Off: Use all channels in the channel list; See +UWCL for more
     ///      information. The channel list will be filtered by 802.11d.
@@ -738,7 +714,7 @@ pub enum WifiConfig {
     ///     0) or by storing the setting (&W) to non-volatile memory and
     ///        restarting the module. Supported software versions 5.0.0 onwards
     #[at_arg(value = 11)]
-    ForceWorldMode(bool),
+    ForceWorldMode(OnOff),
     /// Fast transition mode (802.11r) Supported software versions 6.0.0 onwards
     #[at_arg(value = 12)]
     FastTransitionMode(FastTransitionMode),
@@ -811,13 +787,13 @@ pub enum WifiConfig {
     ///     networks, this may not work. Supported software versions 7.0.0
     ///     onwards
     #[at_arg(value = 22)]
-    ScanFilter(bool),
+    ScanFilter(OnOff),
     /// Enable block acknowledgement
     /// - Off (default): Disable block acknowledgement
     /// - On: Enable block acknowledgement Supported software versions 7.0.2
     ///   onwards
     #[at_arg(value = 23)]
-    BlockAcknowledgment(bool),
+    BlockAcknowledgment(OnOff),
     /// Minimum TLS version. Default: TLS v1.0 Supported software versions 7.0.2
     /// onwards
     #[at_arg(value = 24)]
@@ -891,7 +867,7 @@ pub enum AccessPointConfig {
     /// - 0 (default): Inactive
     /// - 1: active
     #[at_arg(value = 0)]
-    ActiveOnStartup(bool),
+    ActiveOnStartup(OnOff),
     /// SSID - <param_val1> is the Service Set identification of the access
     /// point. The factory-programmed value is ("UBXWifi").
     #[at_arg(value = 2)]
@@ -974,7 +950,7 @@ pub enum AccessPointConfig {
     /// - Bit 0 (default): Disable hidden SSID
     /// - Bit 1: Enable hidden SSID Supported software versions 6.0.0 onwards
     #[at_arg(value = 16)]
-    HiddenSSID(bool),
+    HiddenSSID(OnOff),
     /// White List - <param_val1>...<param_val10> List of MAC addresses of
     /// stations that is allowed to connect or 0 to allow all. The factory
     /// default is 0.
@@ -1014,12 +990,12 @@ pub enum AccessPointConfig {
     /// - 1 Enable DHCP server. The DHCP Server will provide addresses according
     ///   to the following formula: (Static address and subnet mask) + 100
     #[at_arg(value = 106)]
-    DHCPServer(bool),
+    DHCPServer(OnOff),
     /// Address conflict detection. The factory default value is 0 (disabled).
     /// - 0: Disabled
     /// - 1: Enabled Supported software versions 6.0.0 onwards
     #[at_arg(value = 107)]
-    AddressConflictDetection(bool),
+    AddressConflictDetection(OnOff),
     ///  IPv6 Mode - <param_val> to set the way to retrieve an IP address
     /// - 1 (default): Link Local IP address
     #[at_arg(value = 200)]

--- a/ublox-short-range/src/command/wifi/types.rs
+++ b/ublox-short-range/src/command/wifi/types.rs
@@ -7,6 +7,31 @@ use heapless::{String, Vec};
 use serde::Deserialize;
 
 #[derive(Clone, PartialEq, AtatEnum)]
+#[repr(u8)]
+pub enum OnOff {
+    On = 1,
+    Off = 0,
+}
+
+impl From<bool> for OnOff {
+    fn from(b: bool) -> Self {
+        match b {
+            true => Self::On,
+            false => Self::Off,
+        }
+    }
+}
+
+impl Into<bool> for OnOff {
+    fn into(self) -> bool {
+        match self {
+            Self::On => true,
+            Self::Off => false,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, AtatEnum)]
 #[repr(u16)]
 pub enum WifiStationConfigParameter {
     /// <param_val1> decides if the station is active on start up.
@@ -122,7 +147,7 @@ pub enum WifiStationConfig {
     /// - Off (default): Inactive
     /// - On: active
     #[at_arg(value = 0)]
-    ActiveOnStartup(bool),
+    ActiveOnStartup(OnOff),
     ///  SSID - <param_val1> is the Service Set Identifier. The factory default
     /// value is an empty string ("").
     #[at_arg(value = 2)]
@@ -262,7 +287,7 @@ pub enum WifiStationConfigR {
     /// - Off (default): Inactive
     /// - On: active
     #[at_arg(value = 0)]
-    ActiveOnStartup(bool),
+    ActiveOnStartup(OnOff),
     ///  SSID - <param_val1> is the Service Set Identifier. The factory default
     /// value is an empty string ("").
     #[at_arg(value = 2)]

--- a/ublox-short-range/src/command/wifi/urc.rs
+++ b/ublox-short-range/src/command/wifi/urc.rs
@@ -6,6 +6,9 @@ use atat::heapless_bytes::Bytes;
 /// 7.15 Wi-Fi Link connected +UUWLE
 #[derive(Debug, PartialEq, Clone, AtatResp)]
 pub struct WifiLinkConnected {
+    /// Not the config id!
+    /// Shame Ublox!
+    /// UBX-14044127
     #[at_arg(position = 0)]
     pub connection_id: u32,
     #[at_arg(position = 1)]

--- a/ublox-short-range/src/config.rs
+++ b/ublox-short-range/src/config.rs
@@ -77,7 +77,7 @@ where
     }
 
     /// Experimental use of undocumented setting for TLS buffers
-    /// 
+    ///
     /// For Odin:
     /// Minimum is 512 and maximum is 16K (16384).
     /// DEFAULT_TLS_IN_BUFFER_SIZE (7800)
@@ -89,7 +89,7 @@ where
     }
 
     /// Experimental use of undocumented setting for TLS buffers
-    /// 
+    ///
     /// For Odin:
     /// Minimum is 512 and maximum is 16K (16384).
     /// DEFAULT_TLS_OUT_BUFFER_SIZE (3072)

--- a/ublox-short-range/src/config.rs
+++ b/ublox-short-range/src/config.rs
@@ -77,6 +77,10 @@ where
     }
 
     /// Experimental use of undocumented setting for TLS buffers
+    /// 
+    /// For Odin:
+    /// Minimum is 512 and maximum is 16K (16384).
+    /// DEFAULT_TLS_IN_BUFFER_SIZE (7800)
     pub fn tls_in_buffer_size(self, bytes: u16) -> Self {
         Config {
             tls_in_buffer_size: Some(bytes),
@@ -85,6 +89,10 @@ where
     }
 
     /// Experimental use of undocumented setting for TLS buffers
+    /// 
+    /// For Odin:
+    /// Minimum is 512 and maximum is 16K (16384).
+    /// DEFAULT_TLS_OUT_BUFFER_SIZE (3072)
     pub fn tls_out_buffer_size(self, bytes: u16) -> Self {
         Config {
             tls_out_buffer_size: Some(bytes),

--- a/ublox-short-range/src/error.rs
+++ b/ublox-short-range/src/error.rs
@@ -28,6 +28,7 @@ pub enum Error {
     SocketMapMemory,
     Supplicant,
     Timer,
+    ShadowStoreBug,
     _Unknown,
 }
 

--- a/ublox-short-range/src/error.rs
+++ b/ublox-short-range/src/error.rs
@@ -26,6 +26,7 @@ pub enum Error {
     Unimplemented,
     SocketMemory,
     SocketMapMemory,
+    Supplicant,
     Timer,
     _Unknown,
 }

--- a/ublox-short-range/src/wifi/ap.rs
+++ b/ublox-short-range/src/wifi/ap.rs
@@ -57,7 +57,7 @@ where
         )?;
 
         if let Some(ref con) = self.wifi_connection {
-            if con.active {
+            if con.activated {
                 return Err(WifiHotspotError::CreationFailed);
             }
         }
@@ -205,7 +205,7 @@ where
         let ap_config_id = AccessPointId::Id0;
 
         if let Some(ref con) = self.wifi_connection {
-            if con.active{
+            if con.activated{
                 self.send_internal(
                     &EdmAtCmdWrapper(WifiAPAction {
                         ap_config_id,

--- a/ublox-short-range/src/wifi/ap.rs
+++ b/ublox-short-range/src/wifi/ap.rs
@@ -179,22 +179,25 @@ where
             }),
             true,
         )?;
-        
-        self.wifi_connection.replace(WifiConnection::new(
-            WifiNetwork {
-                bssid: Bytes::new(),
-                op_mode: wifi::types::OperationMode::AdHoc,
-                ssid: options.ssid,
-                channel: 0,
-                rssi: 1,
-                authentication_suites: 0,
-                unicast_ciphers: 0,
-                group_ciphers: 0,
-                mode: WifiMode::AccessPoint,
-            },
-            WiFiState::NotConnected,
-            ap_config_id as u8,
-        ).activate());
+
+        self.wifi_connection.replace(
+            WifiConnection::new(
+                WifiNetwork {
+                    bssid: Bytes::new(),
+                    op_mode: wifi::types::OperationMode::AdHoc,
+                    ssid: options.ssid,
+                    channel: 0,
+                    rssi: 1,
+                    authentication_suites: 0,
+                    unicast_ciphers: 0,
+                    group_ciphers: 0,
+                    mode: WifiMode::AccessPoint,
+                },
+                WiFiState::NotConnected,
+                ap_config_id as u8,
+            )
+            .activate(),
+        );
         Ok(())
     }
 
@@ -205,7 +208,7 @@ where
         let ap_config_id = AccessPointId::Id0;
 
         if let Some(ref con) = self.wifi_connection {
-            if con.activated{
+            if con.activated {
                 self.send_internal(
                     &EdmAtCmdWrapper(WifiAPAction {
                         ap_config_id,

--- a/ublox-short-range/src/wifi/ap.rs
+++ b/ublox-short-range/src/wifi/ap.rs
@@ -107,7 +107,7 @@ where
         self.send_internal(
             &EdmAtCmdWrapper(SetWifiAPConfig {
                 ap_config_id,
-                ap_config_param: AccessPointConfig::DHCPServer(true),
+                ap_config_param: AccessPointConfig::DHCPServer(true.into()),
             }),
             true,
         )?;

--- a/ublox-short-range/src/wifi/connection.rs
+++ b/ublox-short-range/src/wifi/connection.rs
@@ -2,6 +2,7 @@ use crate::wifi::network::{WifiMode, WifiNetwork};
 
 #[derive(Debug, Clone, Copy, PartialEq, defmt::Format)]
 pub enum WiFiState {
+    Inactive,
     /// Searching for Wifi
     NotConnected,
     Connected,
@@ -18,13 +19,14 @@ pub enum NetworkState {
 
 // Fold into wifi connectivity
 pub struct WifiConnection {
+    /// Keeps track of connection state on module
     pub wifi_state: WiFiState,
     pub network_state: NetworkState,
     pub network: WifiNetwork,
     /// Numbre from 0-9. 255 used for unknown
     pub config_id: u8,
-    /// Keeps track of activation of the config
-    pub active: bool,
+    /// Keeps track of activation of the config by driver
+    pub activated: bool,
 }
 
 impl WifiConnection {
@@ -34,7 +36,7 @@ impl WifiConnection {
             network_state: NetworkState::Unattached,
             network,
             config_id,
-            active: false,
+            activated: false,
         }
     }
 
@@ -51,11 +53,11 @@ impl WifiConnection {
     }
 
     pub(crate) fn activate(mut self) -> Self {
-        self.active = true;
+        self.activated = true;
         self
     }
 
     pub(crate) fn deactivate(&mut self) {
-        self.active = false;
+        self.activated = false;
     }
 }

--- a/ublox-short-range/src/wifi/connection.rs
+++ b/ublox-short-range/src/wifi/connection.rs
@@ -2,8 +2,6 @@ use crate::wifi::network::{WifiMode, WifiNetwork};
 
 #[derive(Debug, Clone, Copy, PartialEq, defmt::Format)]
 pub enum WiFiState {
-    /// Disconnected, Wifi off
-    Inactive,
     /// Searching for Wifi
     NotConnected,
     Connected,
@@ -23,6 +21,7 @@ pub struct WifiConnection {
     pub wifi_state: WiFiState,
     pub network_state: NetworkState,
     pub network: WifiNetwork,
+    /// Numbre from 0-9. 255 used for unknown
     pub config_id: u8,
     /// Keeps track of activation of the config
     pub active: bool,

--- a/ublox-short-range/src/wifi/supplicant.rs
+++ b/ublox-short-range/src/wifi/supplicant.rs
@@ -133,7 +133,7 @@ where
                     // but should this be the case, the module is already having unexpected behaviour
                 } else {
                     // This causes unexpected behaviour
-                    panic!("Two configs are active on startup!")
+                    defmt::panic!("Two configs are active on startup!")
                 }
             } else if load.is_err() {
                 //Handle shadow store bug
@@ -148,13 +148,15 @@ where
                 if let WifiStationConfigR::SSID(ssid) = parameter {
                     if !ssid.is_empty() {
                         defmt::error!("Shadow store bug!");
-                        self.client
-                            .send(&EdmAtCmdWrapper(ExecWifiStationAction {
-                                config_id,
-                                action: WifiStationAction::Deactivate,
-                            }))
-                            .ok();
-                        // self.remove_connection(config_id).map_err(|_| Error::Supplicant)?;
+                        // defmt::panic!("Shadow store bug!");
+                        // self.client
+                        //     .send(&EdmAtCmdWrapper(ExecWifiStationAction {
+                        //         config_id,
+                        //         action: WifiStationAction::Reset,
+                        //     }))
+                        //     .ok();
+                        self.remove_connection(config_id)
+                            .map_err(|_| Error::Supplicant)?;
                     }
                 }
             }
@@ -504,7 +506,10 @@ where
 
     /// Returns Active on startup config ID if any
     pub fn get_active_on_startup(&self) -> Option<u8> {
-        debug!("[SUP] Get active on startup");
+        debug!(
+            "[SUP] Get active on startup: {:?}",
+            self.active_on_startup.clone()
+        );
         return self.active_on_startup.clone();
     }
 

--- a/ublox-short-range/src/wifi/supplicant.rs
+++ b/ublox-short-range/src/wifi/supplicant.rs
@@ -4,6 +4,7 @@ use heapless::Vec;
 use crate::{
     command::{
         edm::EdmAtCmdWrapper,
+        system::RebootDCE,
         wifi::{
             responses::GetWifiStationConfigResponse,
             types::{
@@ -11,7 +12,7 @@ use crate::{
                 WifiStationConfigParameter, WifiStationConfigR,
             },
             ExecWifiStationAction, GetWifiStationConfig, SetWifiStationConfig, WifiScan,
-        }, system::RebootDCE,
+        },
     },
     error::{Error, WifiConnectionError, WifiError},
 };
@@ -22,7 +23,7 @@ use super::{
     options::ConnectionOptions,
 };
 
-use defmt::{debug, trace};
+use defmt::debug;
 
 /// Supplicant is used to
 ///
@@ -153,7 +154,7 @@ where
                         self.remove_connection(config_id)
                             .map_err(|_| Error::Supplicant)?;
                         self.send_at(&EdmAtCmdWrapper(RebootDCE)).ok();
-                        return Err(Error::ShadowStoreBug)
+                        return Err(Error::ShadowStoreBug);
                     }
                 }
             }

--- a/ublox-short-range/src/wifi/supplicant.rs
+++ b/ublox-short-range/src/wifi/supplicant.rs
@@ -283,7 +283,7 @@ where
         // check for active
         if self.is_config_in_use(config_id) {
             defmt::error!("Config id is active!");
-            return Err(WifiConnectionError::Illigal);
+            return Err(WifiConnectionError::Illegal);
         }
 
         self.send_at(&EdmAtCmdWrapper(ExecWifiStationAction {
@@ -319,7 +319,7 @@ where
         // check for active
         if self.is_config_in_use(config_id) {
             defmt::error!("Config id is active!");
-            return Err(WifiConnectionError::Illigal);
+            return Err(WifiConnectionError::Illegal);
         }
 
         self.send_at(&EdmAtCmdWrapper(ExecWifiStationAction {
@@ -526,12 +526,12 @@ where
             // check for active connection
             if self.is_config_in_use(active_on_startup) {
                 defmt::error!("Active on startup is active!");
-                return Err(WifiConnectionError::Illigal);
+                return Err(WifiConnectionError::Illegal);
             }
         }
         if self.is_config_in_use(config_id) {
             defmt::error!("Config id is active!");
-            return Err(WifiConnectionError::Illigal);
+            return Err(WifiConnectionError::Illegal);
         }
 
         // disable current active on startup
@@ -574,7 +574,7 @@ where
             // check for active connection
             if self.is_config_in_use(active_on_startup) {
                 defmt::error!("Active on startup is active!");
-                return Err(WifiConnectionError::Illigal);
+                return Err(WifiConnectionError::Illegal);
             }
             // if any active remove this asset.
             self.send_at(&EdmAtCmdWrapper(SetWifiStationConfig {

--- a/ublox-short-range/src/wifi/supplicant.rs
+++ b/ublox-short-range/src/wifi/supplicant.rs
@@ -31,7 +31,7 @@ use defmt::{debug, trace};
 /// // Add, activate and remove network
 /// let network = ConnectionOptions::new().ssid("my-ssid").password("hunter2");
 /// let config_id: u8 = 0;
-/// let mut supplicant = ublox.supplicant::<MAX_NETWORKS>()
+/// let mut supplicant = ublox.supplicant::<MAX_NETWORKS>().unwrap();
 ///
 /// supplicant.upsert_connection(config_id, network).unwrap();
 /// supplicant.activate(config_id).unwrap();
@@ -47,6 +47,7 @@ use defmt::{debug, trace};
 pub struct Supplicant<'a, C, const N: usize> {
     pub(crate) client: &'a mut C,
     pub(crate) wifi_connection: &'a mut Option<WifiConnection>,
+    pub(crate) active_on_startup: &'a mut Option<u8>,
 }
 
 impl<'a, C, const N: usize> Supplicant<'a, C, N>
@@ -74,6 +75,25 @@ where
                     action: WifiStationAction::Load,
                 }))
                 .ok();
+
+            let mut active_on_startup = false;
+            let GetWifiStationConfigResponse { parameter, .. } =
+                self.send_at(&EdmAtCmdWrapper(GetWifiStationConfig {
+                    config_id,
+                    parameter: Some(WifiStationConfigParameter::ActiveOnStartup),
+                }))?;
+
+            if let WifiStationConfigR::ActiveOnStartup(active) = parameter {
+                active_on_startup = active;
+            }
+            if active_on_startup {
+                if *self.active_on_startup == None || *self.active_on_startup == Some(config_id) {
+                    *self.active_on_startup = Some(config_id);
+                } else {
+                    // This causes unexpected behaviour
+                    panic!("Two configs are active on startup!")
+                }
+            }
         }
         Ok(())
     }
@@ -182,7 +202,7 @@ where
     /// Removing the active connection is not possible. Deactivate the network first.
     pub fn remove_connection(&mut self, config_id: u8) -> Result<(), WifiConnectionError> {
         // self.deactivate(config_id)?;
-        if let Some(w) = self.wifi_connection {
+        if let Some(ref w) = self.wifi_connection {
             if w.config_id == config_id && w.active {
                 return Err(WifiConnectionError::Illegal);
             }
@@ -368,5 +388,88 @@ where
 
     pub fn flush(&mut self) -> Result<(), WifiConnectionError> {
         todo!()
+    }
+
+    /// Returns Active on startup config ID if any
+    pub fn get_active_on_startup(&self) -> Option<u8> {
+        return self.active_on_startup.clone();
+    }
+
+    /// Sets a config as active on startup, replacing the current.
+    ///
+    /// This is not possible if any of the two are currently active.
+    pub fn set_active_on_startup(&mut self, config_id: u8) -> Result<(), WifiConnectionError> {
+        // check end condition true
+        if let Some(active_on_startup) = *self.active_on_startup {
+            if active_on_startup == config_id {
+                return Ok(());
+            }
+        }
+        // check for any of them as active
+        if let Some(ref con) = self.wifi_connection {
+            if con.config_id == config_id && con.active {
+                return Err(WifiConnectionError::Illigal);
+            }
+        }
+
+        // check and disable current active on startup
+        if let Some(active_on_startup) = self.active_on_startup.clone() {
+            if let Some(ref con) = self.wifi_connection {
+                if con.config_id == active_on_startup && con.active {
+                    return Err(WifiConnectionError::Illigal);
+                }
+            }
+            // if any active on startup remove this parameter.
+            self.send_at(&EdmAtCmdWrapper(SetWifiStationConfig {
+                config_id: active_on_startup,
+                config_param: WifiStationConfig::ActiveOnStartup(false),
+            }))?;
+
+            self.send_at(&EdmAtCmdWrapper(ExecWifiStationAction {
+                config_id: active_on_startup,
+                action: WifiStationAction::Store,
+            }))?;
+        }
+
+        // Insert the new one as active on startup.
+        self.send_at(&EdmAtCmdWrapper(SetWifiStationConfig {
+            config_id,
+            config_param: WifiStationConfig::ActiveOnStartup(false),
+        }))?;
+
+        self.send_at(&EdmAtCmdWrapper(ExecWifiStationAction {
+            config_id,
+            action: WifiStationAction::Store,
+        }))?;
+
+        *self.active_on_startup = Some(config_id);
+
+        Ok(())
+    }
+
+    /// Unsets a config as active on startup, replacing the current.
+    ///
+    /// This is not possible if any of the two are currently active.
+    pub fn unset_active_on_startup(&mut self) -> Result<(), WifiConnectionError> {
+        // check for any of them as active
+        if let Some(active_on_startup) = self.active_on_startup.clone() {
+            if let Some(ref con) = self.wifi_connection {
+                if con.config_id == active_on_startup && con.active {
+                    return Err(WifiConnectionError::Illigal);
+                }
+            }
+            // if any active remove this asset.
+            self.send_at(&EdmAtCmdWrapper(SetWifiStationConfig {
+                config_id: active_on_startup,
+                config_param: WifiStationConfig::ActiveOnStartup(false),
+            }))?;
+
+            self.send_at(&EdmAtCmdWrapper(ExecWifiStationAction {
+                config_id: active_on_startup,
+                action: WifiStationAction::Store,
+            }))?;
+            *self.active_on_startup = None;
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
Active on startup now possible. This caused a rewrite of some parts of the startup handling.
Activation of configs modified and has been demonstrated in an example.
AT parsing of booleans have been fixed.
The a bug has documented and handled where credentials stay in volatile memory after a restart.