### PR TITLE
fix(*): Move usage of undocumented AT command for setting TLS buffer sizes

### DIFF
--- a/ublox-short-range/src/client.rs
+++ b/ublox-short-range/src/client.rs
@@ -187,7 +187,6 @@ where
 
         self.send_internal(&EdmAtCmdWrapper(StoreCurrentConfig), false)?;
 
-      
         if self.firmware_version()? < FirmwareVersion::new(8, 0, 0) {
             self.config.network_up_bug = true;
         } else {

--- a/ublox-short-range/src/config.rs
+++ b/ublox-short-range/src/config.rs
@@ -78,6 +78,7 @@ where
 
     /// Experimental use of undocumented setting for TLS buffers
     pub fn tls_in_buffer_size(self, bytes: u16) -> Self {
+        assert!(bytes > 512);
         Config {
             tls_in_buffer_size: Some(bytes),
             ..self
@@ -86,6 +87,7 @@ where
 
     /// Experimental use of undocumented setting for TLS buffers
     pub fn tls_out_buffer_size(self, bytes: u16) -> Self {
+        assert!(bytes > 512);
         Config {
             tls_out_buffer_size: Some(bytes),
             ..self


### PR DESCRIPTION
 to ublox firmware versions larger than 8.0