### PR TITLE
Fix: TCP peer connect using domain name instead of ip.

### DIFF
--- a/ublox-short-range/src/client.rs
+++ b/ublox-short-range/src/client.rs
@@ -58,7 +58,6 @@ pub enum DNSState {
 /// length is 64 characters.
 /// Domain name length is 128 for NINA-W13 and NINA-W15 software version 4.0
 /// .0 or later.
-
 #[cfg(not(feature = "nina_w1xx"))]
 pub const MAX_DOMAIN_NAME_LENGTH: usize = 64;
 
@@ -71,7 +70,7 @@ pub struct DNSTableEntry {
 }
 
 impl DNSTableEntry {
-    pub fn new(state: DNSState, domain_name: heapless::String<MAX_DOMAIN_NAME_LENGTH>) -> Self {
+    pub const fn new(state: DNSState, domain_name: heapless::String<MAX_DOMAIN_NAME_LENGTH>) -> Self {
         Self { domain_name, state }
     }
 }

--- a/ublox-short-range/src/client.rs
+++ b/ublox-short-range/src/client.rs
@@ -53,6 +53,23 @@ pub enum DNSState {
     Error(PingError),
 }
 
+pub struct DNSTable{
+    pub table: heapless::LinearMap<IpAddr , heapless::String<256>,16>
+}
+
+impl DNSTable {
+    fn new() -> Self{
+        Self { table: heapless::LinearMap::new() }
+    }
+    pub fn insert(&mut self, ip: IpAddr, hostname: heapless::String<256>,) -> Result<(), ()>{
+        self.table.insert(ip, hostname).ok();
+        Ok(())
+    }
+    pub fn get_hostname_by_ip(&self, ip: &IpAddr) -> Option<&heapless::String<256>>{
+        self.table.get(ip)
+    }
+}
+
 #[derive(PartialEq, Clone, Default)]
 pub struct SecurityCredentials {
     pub ca_cert_name: Option<heapless::String<16>>,
@@ -84,6 +101,7 @@ where
     pub(crate) module_started: bool,
     pub(crate) initialized: bool,
     serial_mode: SerialMode,
+    pub dns_table: DNSTable,
     pub(crate) wifi_connection: Option<WifiConnection>,
     pub(crate) wifi_config_active_on_startup: Option<u8>,
     pub(crate) client: C,
@@ -109,6 +127,7 @@ where
             module_started: false,
             initialized: false,
             serial_mode: SerialMode::Cmd,
+            dns_table: DNSTable::new(),
             wifi_connection: None,
             wifi_config_active_on_startup: None,
             client,

--- a/ublox-short-range/src/client.rs
+++ b/ublox-short-range/src/client.rs
@@ -53,19 +53,21 @@ pub enum DNSState {
     Error(PingError),
 }
 
-pub struct DNSTable{
-    pub table: heapless::LinearMap<IpAddr , heapless::String<256>,16>
+pub struct DNSTable {
+    pub table: heapless::LinearMap<IpAddr, heapless::String<256>, 16>,
 }
 
 impl DNSTable {
-    fn new() -> Self{
-        Self { table: heapless::LinearMap::new() }
+    fn new() -> Self {
+        Self {
+            table: heapless::LinearMap::new(),
+        }
     }
-    pub fn insert(&mut self, ip: IpAddr, hostname: heapless::String<256>,) -> Result<(), ()>{
+    pub fn insert(&mut self, ip: IpAddr, hostname: heapless::String<256>) -> Result<(), ()> {
         self.table.insert(ip, hostname).ok();
         Ok(())
     }
-    pub fn get_hostname_by_ip(&self, ip: &IpAddr) -> Option<&heapless::String<256>>{
+    pub fn get_hostname_by_ip(&self, ip: &IpAddr) -> Option<&heapless::String<256>> {
         self.table.get(ip)
     }
 }

--- a/ublox-short-range/src/client.rs
+++ b/ublox-short-range/src/client.rs
@@ -65,14 +65,14 @@ pub const MAX_DOMAIN_NAME_LENGTH: usize = 64;
 #[cfg(feature = "nina_w1xx")]
 pub const MAX_DOMAIN_NAME_LENGTH: usize = 128;
 
-pub struct DNSTableEntry{
+pub struct DNSTableEntry {
     domain_name: heapless::String<MAX_DOMAIN_NAME_LENGTH>,
-    state: DNSState
+    state: DNSState,
 }
 
 impl DNSTableEntry {
-    pub fn new(state: DNSState, domain_name: heapless::String<MAX_DOMAIN_NAME_LENGTH>) -> Self{
-        Self {domain_name, state }
+    pub fn new(state: DNSState, domain_name: heapless::String<MAX_DOMAIN_NAME_LENGTH>) -> Self {
+        Self { domain_name, state }
     }
 }
 
@@ -86,29 +86,40 @@ impl DNSTable {
             table: heapless::Deque::new(),
         }
     }
-    pub fn upsert(&mut self, new_entry: DNSTableEntry){
-        if let Some(entry) = self.table.iter_mut().find(|e| e.domain_name == new_entry.domain_name){
+    pub fn upsert(&mut self, new_entry: DNSTableEntry) {
+        if let Some(entry) = self
+            .table
+            .iter_mut()
+            .find(|e| e.domain_name == new_entry.domain_name)
+        {
             entry.state = new_entry.state;
             return;
         }
-        
-        if self.table.is_full(){
+
+        if self.table.is_full() {
             self.table.pop_front();
         }
-        unsafe{
+        unsafe {
             self.table.push_back_unchecked(new_entry);
         }
     }
 
-    pub fn get_state(&self, domain_name: heapless::String<MAX_DOMAIN_NAME_LENGTH>) -> Option<DNSState> {
-        match self.table.iter().find(|e| e.domain_name == domain_name){
+    pub fn get_state(
+        &self,
+        domain_name: heapless::String<MAX_DOMAIN_NAME_LENGTH>,
+    ) -> Option<DNSState> {
+        match self.table.iter().find(|e| e.domain_name == domain_name) {
             Some(entry) => Some(entry.state),
-            None => None
+            None => None,
         }
     }
-    pub fn reverse_lookup(&self, ip: IpAddr) -> Option<&heapless::String<MAX_DOMAIN_NAME_LENGTH>>{
-        match self.table.iter().find(|e| e.state == DNSState::Resolved(ip)) {
-            Some(entry) => {Some(&entry.domain_name)},
+    pub fn reverse_lookup(&self, ip: IpAddr) -> Option<&heapless::String<MAX_DOMAIN_NAME_LENGTH>> {
+        match self
+            .table
+            .iter()
+            .find(|e| e.state == DNSState::Resolved(ip))
+        {
+            Some(entry) => Some(&entry.domain_name),
             None => None,
         }
     }

--- a/ublox-short-range/src/command/edm/urc.rs
+++ b/ublox-short-range/src/command/edm/urc.rs
@@ -6,6 +6,7 @@ use atat::AtatUrc;
 use embedded_nal::{Ipv4Addr, Ipv6Addr};
 use heapless::Vec;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum EdmEvent {
     BluetoothConnectEvent(BluetoothConnectEvent),
@@ -38,10 +39,10 @@ impl AtatUrc for EdmEvent {
                 || resp.len() == AUTOCONNECTMESSAGE.len() + 1
             {
                 let mut urc = resp;
-                match urc.iter().position(|x| !x.is_ascii_whitespace()) {
-                    Some(i) => urc = &urc[i..],
-                    None => (),
+                if let Some(i) = urc.iter().position(|x| !x.is_ascii_whitespace()) {
+                    urc = &urc[i..];
                 };
+
                 let cmd = Urc::parse(urc)?;
                 return EdmEvent::ATEvent(cmd).into();
             }
@@ -70,9 +71,8 @@ impl AtatUrc for EdmEvent {
         match resp[4].into() {
             PayloadType::ATEvent => {
                 let mut urc = &resp[AT_COMMAND_POSITION..PAYLOAD_POSITION + payload_len];
-                match urc.iter().position(|x| !x.is_ascii_whitespace()) {
-                    Some(i) => urc = &urc[i..],
-                    None => (),
+                if let Some(i) = urc.iter().position(|x| !x.is_ascii_whitespace()) {
+                    urc = &urc[i..];
                 };
                 let cmd = Urc::parse(urc)?;
                 EdmEvent::ATEvent(cmd).into()
@@ -184,9 +184,9 @@ mod test {
             handle: PeerHandle(2),
             connection_type: crate::command::data_mode::types::ConnectionType::IPv4,
             protocol: crate::command::data_mode::types::IPProtocol::UDP,
-            local_address: Bytes::from_slice(&"0.0.0.0".as_bytes()).unwrap(),
+            local_address: Bytes::from_slice("0.0.0.0".as_bytes()).unwrap(),
             local_port: 0,
-            remote_address: Bytes::from_slice(&"162.159.200.1".as_bytes()).unwrap(),
+            remote_address: Bytes::from_slice("162.159.200.1".as_bytes()).unwrap(),
             remote_port: 123,
         }));
         let parsed_urc = EdmEvent::parse(resp);

--- a/ublox-short-range/src/command/general/types.rs
+++ b/ublox-short-range/src/command/general/types.rs
@@ -27,7 +27,7 @@ pub enum IdentificationInfoEnum {
     MCUID = 10,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FirmwareVersion {
     major: u8,
     minor: u8,

--- a/ublox-short-range/src/command/mod.rs
+++ b/ublox-short-range/src/command/mod.rs
@@ -105,12 +105,3 @@ impl From<bool> for OnOff {
         }
     }
 }
-
-impl Into<bool> for OnOff {
-    fn into(self) -> bool {
-        match self {
-            Self::On => true,
-            Self::Off => false,
-        }
-    }
-}

--- a/ublox-short-range/src/wifi/dns.rs
+++ b/ublox-short-range/src/wifi/dns.rs
@@ -45,10 +45,12 @@ where
 
         match self.dns_state {
             DNSState::Resolved(ip) => {
-                //Insert hostname and ip into dns table 
-                self.dns_table.insert(ip, heapless::String::from(hostname)).ok(); 
+                //Insert hostname and ip into dns table
+                self.dns_table
+                    .insert(ip, heapless::String::from(hostname))
+                    .ok();
                 Ok(ip)
-            },
+            }
             _ => Err(nb::Error::Other(Error::Illegal)),
         }
     }

--- a/ublox-short-range/src/wifi/dns.rs
+++ b/ublox-short-range/src/wifi/dns.rs
@@ -44,7 +44,11 @@ where
         }
 
         match self.dns_state {
-            DNSState::Resolved(ip) => Ok(ip),
+            DNSState::Resolved(ip) => {
+                //Insert hostname and ip into dns table 
+                self.dns_table.insert(ip, heapless::String::from(hostname)).ok(); 
+                Ok(ip)
+            },
             _ => Err(nb::Error::Other(Error::Illegal)),
         }
     }

--- a/ublox-short-range/src/wifi/dns.rs
+++ b/ublox-short-range/src/wifi/dns.rs
@@ -1,4 +1,4 @@
-use crate::client::DNSState;
+use crate::client::{DNSState, DNSTableEntry};
 use embedded_hal::digital::OutputPin;
 use embedded_nal::{nb, AddrType, Dns, IpAddr};
 use fugit::ExtU32;
@@ -31,27 +31,30 @@ where
             retry_num: 1,
         })
         .map_err(|_| nb::Error::Other(Error::Unaddressable))?;
-        self.dns_state = DNSState::Resolving;
+
+        self.dns_table.upsert(DNSTableEntry::new(DNSState::Resolving, String::from(hostname)));
 
         let expiration = self.timer.now() + 8.secs();
 
-        while self.dns_state == DNSState::Resolving {
+        while let Some(DNSState::Resolving) = self.dns_table.get_state(String::from(hostname)){
             self.spin().map_err(|_| nb::Error::Other(Error::Illegal))?;
 
             if self.timer.now() >= expiration {
-                return Err(nb::Error::Other(Error::Timeout));
+                break;
             }
         }
 
-        match self.dns_state {
-            DNSState::Resolved(ip) => {
-                //Insert hostname and ip into dns table
-                self.dns_table
-                    .insert(ip, heapless::String::from(hostname))
-                    .ok();
+        match self.dns_table.get_state(String::from(hostname)) {
+            Some(DNSState::Resolved(ip)) => {
                 Ok(ip)
             }
-            _ => Err(nb::Error::Other(Error::Illegal)),
+            Some(DNSState::Resolving) => {
+                self.dns_table.upsert(DNSTableEntry::new(DNSState::Error(types::PingError::Timeout), String::from(hostname)));
+                Err(nb::Error::Other(Error::Timeout))
+            }
+            _ => Err(nb::Error::Other(Error::Illegal))
         }
     }
 }
+
+

--- a/ublox-short-range/src/wifi/mod.rs
+++ b/ublox-short-range/src/wifi/mod.rs
@@ -24,6 +24,12 @@ pub(crate) const EGRESS_CHUNK_SIZE: usize = 512;
 /// and the modems `PeerHandle` and `ChannelId`. The peer handle is used
 /// for controlling the connection, while the channel id is used for sending
 /// data over the connection in EDM mode.
+
+pub enum SocketMapError {
+    Full,
+    NotFound,
+}
+
 pub struct SocketMap {
     channel_map: heapless::FnvIndexMap<ChannelId, SocketHandle, 4>,
     peer_map: heapless::FnvIndexMap<PeerHandle, SocketHandle, 4>,
@@ -47,18 +53,17 @@ impl SocketMap {
         &mut self,
         channel_id: ChannelId,
         socket_handle: SocketHandle,
-    ) -> Result<(), ()> {
+    ) -> Result<(), SocketMapError> {
         defmt::trace!("[SOCK_MAP] {:?} tied to {:?}", socket_handle, channel_id);
-        self.channel_map
-            .insert(channel_id, socket_handle)
-            .map_err(drop)?;
-        Ok(())
+        match self.channel_map.insert(channel_id, socket_handle) {
+            Ok(_) => Ok(()),
+            Err(_) => Err(SocketMapError::Full),
+        }
     }
 
-    pub fn remove_channel(&mut self, channel_id: &ChannelId) -> Result<(), ()> {
+    pub fn remove_channel(&mut self, channel_id: &ChannelId) {
         defmt::trace!("[SOCK_MAP] {:?} removed", channel_id);
-        self.channel_map.remove(channel_id).ok_or(())?;
-        Ok(())
+        self.channel_map.remove(channel_id);
     }
 
     pub fn channel_to_socket(&self, channel_id: &ChannelId) -> Option<&SocketHandle> {
@@ -71,16 +76,21 @@ impl SocketMap {
             .find_map(|(c, s)| if s == socket_handle { Some(c) } else { None })
     }
 
-    pub fn insert_peer(&mut self, peer: PeerHandle, socket_handle: SocketHandle) -> Result<(), ()> {
+    pub fn insert_peer(
+        &mut self,
+        peer: PeerHandle,
+        socket_handle: SocketHandle,
+    ) -> Result<(), SocketMapError> {
         defmt::trace!("[SOCK_MAP] {:?} tied to {:?}", socket_handle, peer);
-        self.peer_map.insert(peer, socket_handle).map_err(drop)?;
+        if self.peer_map.insert(peer, socket_handle).is_err() {
+            return Err(SocketMapError::Full);
+        };
         Ok(())
     }
 
-    pub fn remove_peer(&mut self, peer: &PeerHandle) -> Result<(), ()> {
+    pub fn remove_peer(&mut self, peer: &PeerHandle) {
         defmt::trace!("[SOCK_MAP] {:?} removed", peer);
-        self.peer_map.remove(peer).ok_or(())?;
-        Ok(())
+        self.peer_map.remove(peer);
     }
 
     pub fn peer_to_socket(&self, peer: &PeerHandle) -> Option<&SocketHandle> {

--- a/ublox-short-range/src/wifi/peer_builder.rs
+++ b/ublox-short-range/src/wifi/peer_builder.rs
@@ -56,7 +56,8 @@ impl<'a> PeerUrlBuilder<'a> {
         write!(&mut s, "?").ok();
         self.local_port
             .map(|v| write!(&mut s, "local_port={}&", v).ok());
-        self.creds.as_ref().map(|creds| {
+
+        if let Some(creds) = self.creds.as_ref() {
             creds
                 .ca_cert_name
                 .as_ref()
@@ -69,7 +70,7 @@ impl<'a> PeerUrlBuilder<'a> {
                 .c_key_name
                 .as_ref()
                 .map(|v| write!(&mut s, "privKey={}&", v).ok());
-        });
+        }
         // Remove trailing '&' or '?' if no query.
         s.pop();
 

--- a/ublox-short-range/src/wifi/supplicant.rs
+++ b/ublox-short-range/src/wifi/supplicant.rs
@@ -96,7 +96,7 @@ where
 
             if parameter == WifiStationConfigR::ActiveOnStartup(true.into()) {
                 debug!("[SUP] Config {:?} is active on startup", config_id);
-                if *self.active_on_startup == None || *self.active_on_startup == Some(config_id) {
+                if self.active_on_startup.is_none() || *self.active_on_startup == Some(config_id) {
                     *self.active_on_startup = Some(config_id);
                     // Update wifi connection
                     if self.wifi_connection.is_none() {
@@ -502,12 +502,12 @@ where
             "[SUP] Get active on startup: {:?}",
             self.active_on_startup.clone()
         );
-        return self.active_on_startup.clone();
+        *self.active_on_startup
     }
 
     /// Returns Active on startup config ID if any
     pub fn has_active_on_startup(&self) -> bool {
-        return self.active_on_startup.is_some();
+        self.active_on_startup.is_some()
     }
 
     /// Sets a config as active on startup, replacing the current.
@@ -567,7 +567,7 @@ where
     pub fn unset_active_on_startup(&mut self) -> Result<(), WifiConnectionError> {
         debug!("[SUP] Unset active on startup connection");
         // check for any of them as active
-        if let Some(active_on_startup) = self.active_on_startup.clone() {
+        if let Some(active_on_startup) = *self.active_on_startup {
             // check for active connection
             if self.is_config_in_use(active_on_startup) {
                 defmt::error!("Active on startup is active!");

--- a/ublox-short-range/src/wifi/tcp_stack.rs
+++ b/ublox-short-range/src/wifi/tcp_stack.rs
@@ -68,13 +68,14 @@ where
         let mut url = PeerUrlBuilder::new();
 
         //Connect with hostname if seen before
-        if let Some(hostname) = self.dns_table.get_hostname_by_ip(&remote.ip()){
+        if let Some(hostname) = self.dns_table.get_hostname_by_ip(&remote.ip()) {
             url.hostname(hostname).port(remote.port());
-        }else {
+        } else {
             url.address(&remote);
         }
 
-        let url = url.creds(self.security_credentials.clone())
+        let url = url
+            .creds(self.security_credentials.clone())
             .tcp()
             .map_err(|_| Error::Unaddressable)?;
         defmt::debug!("[TCP] Connecting socket: {:?} to url: {=str}", socket, url);

--- a/ublox-short-range/src/wifi/tcp_stack.rs
+++ b/ublox-short-range/src/wifi/tcp_stack.rs
@@ -155,7 +155,7 @@ where
         if let Some(ref mut sockets) = self.sockets {
             let tcp = sockets
                 .get::<TcpSocket<TIMER_HZ, L>>(*socket)
-                .map_err(|e| nb::Error::Other(e.into()))?;
+                .map_err(nb::Error::Other)?;
 
             if !tcp.is_connected() {
                 return Err(Error::SocketClosed.into());

--- a/ublox-short-range/src/wifi/tcp_stack.rs
+++ b/ublox-short-range/src/wifi/tcp_stack.rs
@@ -65,14 +65,20 @@ where
         defmt::debug!("[TCP] Connect socket");
         self.connected_to_network().map_err(|_| Error::Illegal)?;
 
-        let url = if let Some(hostname) = self.dns_table.reverse_lookup(remote.ip()){
-            PeerUrlBuilder::new().hostname(hostname.as_str()).port(remote.port()).creds(self.security_credentials.clone())
-            .tcp()
-            .map_err(|_| Error::Unaddressable)?
+        let url = if let Some(hostname) = self.dns_table.reverse_lookup(remote.ip()) {
+            PeerUrlBuilder::new()
+                .hostname(hostname.as_str())
+                .port(remote.port())
+                .creds(self.security_credentials.clone())
+                .tcp()
+                .map_err(|_| Error::Unaddressable)?
         } else {
-            PeerUrlBuilder::new().ip_addr(remote.ip()).port(remote.port()).creds(self.security_credentials.clone())
-            .tcp()
-            .map_err(|_| Error::Unaddressable)?
+            PeerUrlBuilder::new()
+                .ip_addr(remote.ip())
+                .port(remote.port())
+                .creds(self.security_credentials.clone())
+                .tcp()
+                .map_err(|_| Error::Unaddressable)?
         };
 
         defmt::debug!("[TCP] Connecting socket: {:?} to url: {=str}", socket, url);

--- a/ublox-short-range/src/wifi/udp_stack.rs
+++ b/ublox-short-range/src/wifi/udp_stack.rs
@@ -87,7 +87,7 @@ where
         {
             Ok(resp) => self
                 .socket_map
-                .insert_peer(resp.peer_handle.into(), *socket)
+                .insert_peer(resp.peer_handle, *socket)
                 .map_err(|_| Error::InvalidSocket)?,
 
             Err(e) => {
@@ -179,7 +179,7 @@ where
                     .map_err(|_| Self::Error::InvalidSocket)?;
 
                 let bytes = udp.recv_slice(buffer).map_err(Self::Error::from)?;
-                Ok((bytes, remote.clone()))
+                Ok((bytes, *remote))
             } else {
                 Err(Error::Illegal.into())
             }
@@ -346,7 +346,7 @@ where
         // Check incomming sockets for the socket address
         if let Some(connection_socket) = self.udp_listener.get_outgoing(socket, remote) {
             if let Some(ref mut sockets) = self.sockets {
-                if buffer.len() == 0 {
+                if buffer.is_empty() {
                     self.close(connection_socket)?;
                     return Ok(());
                 }


### PR DESCRIPTION
Because embedded-nal TcpClientStack connect function only takes in SocketAddr we can't connect with the domain name.
To fix this we have created a DNS table. When we use the TCP connect function we look up the IP address in the DNS-table to get the domain name. 