### PR TITLE
fix: EdmEvent connectEvent insert channel only for event protocol type

### DIFF
--- a/ublox-short-range/src/client.rs
+++ b/ublox-short-range/src/client.rs
@@ -727,8 +727,8 @@ where
                             }
                         } else {
                             for (h, s) in sockets.iter_mut() {
-                                match event.protocol {
-                                    Protocol::TCP => {
+                                match (&event.protocol, s.get_type()) {
+                                    (Protocol::TCP, SocketType::Tcp) => {
                                         let mut tcp = TcpSocket::downcast(s)?;
                                         if tcp.endpoint() == Some(endpoint) {
                                             self.socket_map
@@ -737,7 +737,7 @@ where
                                             tcp.set_state(TcpState::Connected(endpoint));
                                         }
                                     }
-                                    Protocol::UDP => {
+                                    (Protocol::UDP, SocketType::Udp) => {
                                         let mut udp = UdpSocket::downcast(s)?;
                                         if udp.endpoint() == Some(endpoint) {
                                             self.socket_map
@@ -772,8 +772,8 @@ where
                             }
                         } else {
                             for (h, s) in sockets.iter_mut() {
-                                match event.protocol {
-                                    Protocol::TCP => {
+                                match (&event.protocol, s.get_type()) {
+                                    (Protocol::TCP, SocketType::Tcp) => {
                                         let mut tcp = TcpSocket::downcast(s)?;
                                         if tcp.endpoint() == Some(endpoint) {
                                             self.socket_map
@@ -782,7 +782,7 @@ where
                                             tcp.set_state(TcpState::Connected(endpoint));
                                         }
                                     }
-                                    Protocol::UDP => {
+                                    (Protocol::UDP, SocketType::Udp) => {
                                         let mut udp = UdpSocket::downcast(s)?;
                                         if udp.endpoint() == Some(endpoint) {
                                             self.socket_map


### PR DESCRIPTION
When receiving an Ipv4ConnectEvent we have a for loop that goes through each socket and updates the socketmap. 
The function TcpSocket::downcast(s) only take in a TCP socket and  UdpSocket::downcast(s) only takes in UPD socket. We had a problem because we didn't check what type of protocol the socket in Sockets was. This resulted in passing a TCP socket to UdpSocket::downcast(s). The same thing could happen the other way around. 


- [x] Fix Ipv4connectEvent downcast problem
- [x] Fix remove peer upon error and close socket.