### PR TITLE
(feature): Add simple activate if module already have config

### DIFF
--- a/ublox-short-range/src/wifi/sta.rs
+++ b/ublox-short-range/src/wifi/sta.rs
@@ -213,24 +213,14 @@ where
     }
 
     pub fn disconnect(&mut self) -> Result<(), WifiConnectionError> {
-        if let Some(con) = self.wifi_connection.take() {
-            match con.wifi_state {
-                WiFiState::Connected | WiFiState::NotConnected => {
-                    defmt::debug!("Disconnecting from {:?}", con.network.ssid);
-                    // con.wifi_state = WiFiState::Inactive;
-                    self.send_internal(
-                        &EdmAtCmdWrapper(ExecWifiStationAction {
-                            config_id: CONFIG_ID,
-                            action: WifiStationAction::Deactivate,
-                        }),
-                        true,
-                    )?;
-                }
-                WiFiState::Inactive => {}
-            }
-        } else {
-            return Err(WifiConnectionError::FailedToDisconnect);
-        }
+        defmt::debug!("Disconnecting");
+        self.send_internal(
+            &EdmAtCmdWrapper(ExecWifiStationAction {
+                config_id: CONFIG_ID,
+                action: WifiStationAction::Deactivate,
+            }),
+            true,
+        )?;
         Ok(())
     }
 }


### PR DESCRIPTION
I have added 3 functions 

1. Get ssid of profile 0.
2. Activate wifi with profile 0 config. This requires the module to already have wifi configuration.
3. Reset config, should remove the stored wifi configuration. 