### PR TITLE
fix: Remove wait_for_initialized from wait_leave

### DIFF
--- a/src/asynch/control.rs
+++ b/src/asynch/control.rs
@@ -700,7 +700,6 @@ impl<'a, const INGRESS_BUF_SIZE: usize, const URC_CAPACITY: usize>
 
     /// Leave the wifi and wait, with which we are currently associated.
     pub async fn wait_leave(&self) -> Result<(), Error> {
-        self.state_ch.wait_for_initialized().await;
         self.state_ch.set_should_connect(false);
         self.state_ch.update_connection_with(|con| {
             con.reset();


### PR DESCRIPTION
## Summary
- Removes `self.state_ch.wait_for_initialized().await` from `wait_leave()` in `control.rs`
- When the wifi module never initializes (e.g. stuck probing baud rates), this call blocks forever, preventing cellular fallback from connecting
- The sync `leave()` already performs the same operations without this gate, confirming it's safe to remove

## Test plan
- [x] Tested on device with non-responsive wifi module — cellular fallback now connects successfully